### PR TITLE
CORE-1689: added code to register default resource types and update o…

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -4,11 +4,59 @@ import (
 	"database/sql"
 
 	"github.com/cyverse-de/dbutil"
+	"github.com/cyverse/QMS/internal/model"
 	_ "github.com/lib/pq"
 
 	"github.com/pkg/errors"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
+
+// addInitialResourceTypes inserts the default resource types in the QMS database if they don't exist already.
+func addInitialResourceTypes(gormdb *gorm.DB) error {
+	initialResourceTypes := []model.ResourceType{
+		{
+			Name: "cpu.hours",
+			Unit: "cpu hours",
+		},
+		{
+			Name: "data.size",
+			Unit: "bytes",
+		},
+	}
+
+	// Add the resource types.
+	for _, rt := range initialResourceTypes {
+		err := gormdb.Clauses(clause.OnConflict{DoNothing: true}).Create(&rt).Error
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// addInitialUpdateTypes inserts the default update types in the QMS database if they don't exist already.
+func addInitialUpdateOperations(gormdb *gorm.DB) error {
+	initialUpdateOperations := []model.UpdateOperation{
+		{
+			Name: "ADD",
+		},
+		{
+			Name: "SET",
+		},
+	}
+
+	// Add the update operations.
+	for _, op := range initialUpdateOperations {
+		err := gormdb.Clauses(clause.OnConflict{DoNothing: true}).Create(&op).Error
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
 
 // InitDatabase establishes a database connection and verifies that the database can be reached.
 func Init(driverName, databaseURI string) (*sql.DB, *gorm.DB, error) {
@@ -32,6 +80,14 @@ func Init(driverName, databaseURI string) (*sql.DB, *gorm.DB, error) {
 	if err != nil {
 		return nil, nil, errors.Wrap(err, wrapMsg)
 	}
-	return conn, gormdb, nil
+	err = addInitialResourceTypes(gormdb)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, wrapMsg)
+	}
+	err = addInitialUpdateOperations(gormdb)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, wrapMsg)
+	}
 
+	return conn, gormdb, nil
 }

--- a/internal/model/update.go
+++ b/internal/model/update.go
@@ -6,14 +6,24 @@ import (
 	"gorm.io/gorm"
 )
 
+// UpdateOperation defines the structure of an available update operation in the QMS database.
+//
+// swagger:model
 type UpdateOperation struct {
-	ID   *string `gorm:"type:uuid;default:uuid_generate_v1()" json:"id"`
-	Name string  `gorm:"json:name"`
+	// The update operation ID
+	//
+	// required: true
+	// readOnly: true
+	ID *string `gorm:"type:uuid;default:uuid_generate_v1()" json:"id"`
+	// The update operation name
+	//
+	// required: true
+	Name string `gorm:"type:text;not null;unique" json:"name"`
 }
 
 type TrackedMetric struct {
-	Quota string `gorm:"json:quota"`
-	Usage string `gorm:"json:usage"`
+	Quota string `gorm:"not null" json:"quota"`
+	Usage string `gorm:"not null" json:"usage"`
 }
 
 type Update struct {


### PR DESCRIPTION
…perations

I haven't found a way to get GORM to automatically update the constraints of existing columns (admittedly, I haven't spent a lot of time looking for a way to do this yet), but this works if we nuke the database and restart QMS. We may have to do this a few times until the schema stabilizes unless we can find a way to get GORM to do it automatically for us.
