### PR TITLE
Change a Param() call to QueryParam in AddUsages()

### DIFF
--- a/internal/controllers/users.go
+++ b/internal/controllers/users.go
@@ -208,7 +208,7 @@ func (s Server) AddUsages(ctx echo.Context) error {
 	if resourceName == "" {
 		return model.Error(ctx, "invalid resource name", http.StatusBadRequest)
 	}
-	usageValueString := ctx.Param("usage_value")
+	usageValueString := ctx.QueryParam("usage_value")
 	if usageValueString == "" {
 		return model.Error(ctx, "invalid usage value", http.StatusBadRequest)
 	}


### PR DESCRIPTION
The `Param("usage_value")` tries to read the value from a path parameter, but the route doesn't define a variable of that name. I've switched it to grabbing the value from a query parameter.