### PR TITLE
Fix a few errors

### DIFF
--- a/internal/controllers/users.go
+++ b/internal/controllers/users.go
@@ -75,19 +75,19 @@ func (s Server) AddUser(ctx echo.Context) error {
 	if err != nil {
 		return model.Error(ctx, err.Error(), http.StatusInternalServerError)
 	}
-	userID := *user.ID
+	userID := user.ID
 	var plan = model.Plan{}
 	err = s.GORMDB.Debug().Find(&plan, "name=?", "Basic").Error
 	if err != nil {
 		return model.Error(ctx, "plan name not found.", http.StatusInternalServerError)
 	}
-	planId := *plan.ID
+	planId := plan.ID
 	startDate := time.Now()
 	endDate := startDate.AddDate(1, 0, 0)
 	var userPlan = model.UserPlan{
 		AddedBy:            "Admin",
-		UserID:             &userID,
-		PlanID:             &planId,
+		UserID:             userID,
+		PlanID:             planId,
 		EffectiveStartDate: startDate,
 		EffectiveEndDate:   endDate,
 	}
@@ -95,8 +95,8 @@ func (s Server) AddUser(ctx echo.Context) error {
 	if err != nil {
 		return model.Error(ctx, err.Error(), http.StatusInternalServerError)
 	}
-	storage := "STORAGE"
-	cpu := "CPU"
+	storage := "data.size"
+	cpu := "cpu.hours"
 	var storageResource = model.ResourceType{}
 	var cpuResource = model.ResourceType{}
 	err = s.GORMDB.Debug().
@@ -104,14 +104,14 @@ func (s Server) AddUser(ctx echo.Context) error {
 	if err != nil {
 		return model.Error(ctx, "resource not Found: "+storage, http.StatusInternalServerError)
 	}
-	storageId := *storageResource.ID
+	storageId := storageResource.ID
 	err = s.GORMDB.Debug().
 		Find(&cpuResource, "name=?", cpu).Error
 	if err != nil {
 		return model.Error(ctx, "resource not found.: "+cpu, http.StatusInternalServerError)
 	}
-	cpuId := *cpuResource.ID
-	userPlanId := *userPlan.ID
+	cpuId := cpuResource.ID
+	userPlanId := userPlan.ID
 	var defaultStorageQuota = model.PlanQuotaDefault{}
 	err = s.GORMDB.Debug().
 		Find(&defaultStorageQuota, "resource_type_id=?", storageId).Error
@@ -131,14 +131,14 @@ func (s Server) AddUser(ctx echo.Context) error {
 	var userQuota = []model.Quota{
 		{
 			AddedBy:        "Admin",
-			UserPlanID:     &userPlanId,
-			ResourceTypeID: &storageId,
+			UserPlanID:     userPlanId,
+			ResourceTypeID: storageId,
 			Quota:          defaultStorageQuotaValue,
 		},
 		{
 			AddedBy:        "Admin",
-			UserPlanID:     &userPlanId,
-			ResourceTypeID: &cpuId,
+			UserPlanID:     userPlanId,
+			ResourceTypeID: cpuId,
 			Quota:          defaultCPUQuotaValue,
 		},
 	}

--- a/internal/model/usage.go
+++ b/internal/model/usage.go
@@ -7,10 +7,10 @@ import (
 // Usage define the structure for API Usages.
 type Usage struct {
 	gorm.Model
-	ID             *string      `gorm:"json:id" type:"uuid;default:uuid_generate_v1()"`
-	Usage          float64      `gorm:"not null"`
-	AddedBy        string       `gorm:"json:added_by"`
-	LastModifiedBy string       `gorm:"json:last_modified_by"`
+	ID             *string      `gorm:"type:uuid;default:uuid_generate_v1()" json:"id"`
+	Usage          float64      `gorm:"not null" json:"usage"`
+	AddedBy        string       `gorm:"type:text" json:"added_by"`
+	LastModifiedBy string       `gorm:"type:text" json:"last_modified_by"`
 	UserPlanID     *string      `gorm:"type:uuid;not null" json:"-"`
 	UserPlan       UserPlan     `json:"user_plans"`
 	ResourceTypeID *string      `gorm:"type:uuid;not null" json:"-"`


### PR DESCRIPTION
I ran out of time today, so I don't have the `POST /v1/admin/usages/:username/:resource-type` endpoint fully functional yet. Since I'm going to be out of the office, however, I wanted to get my changes in today. Here's what's working so far.

Create the basic plan. I'm currently doing this directly in the database:

```
qms=# insert into plans (name, description) values ('Basic', 'Basic Plan');
INSERT 0 1
```

Add the user:

```
$ curl -sX PUT "http://localhost:9000/v1/admin/users/sarahr"
{"result":"Success","status":"OK"}
```

Attempt to log the usage:

```
$ curl -sX POST "http://localhost:9000/v1/admin/usages/sarahr/cpu.hours?usage_value=42"
{"error":"pq: null value in column \"user_plan_id\" of relation \"usages\" violates not-null constraint","status":"Internal Server Error"}
```

This is where I'm encountering a problem. The `user_plan` entry exists, but apparently the query that we're using isn't finding it:

```
qms=# select id, effective_start_date, effective_end_date from user_plans where user_id = (select id from users where user_name = 'sarahr');
                  id                  |     effective_start_date      |      effective_end_date
--------------------------------------+-------------------------------+-------------------------------
 6e01efca-9052-11ec-9a0f-406c8f3e9cbb | 2022-02-17 17:33:44.897136-07 | 2023-02-17 17:33:44.897136-07
(1 row)
```

I haven't had time to troubleshoot this yet.
