### PR TITLE
Associate updates with a user

### DIFF
--- a/internal/controllers/util.go
+++ b/internal/controllers/util.go
@@ -1,0 +1,27 @@
+package controllers
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/cyverse/QMS/internal/db"
+	"github.com/cyverse/QMS/internal/model"
+	"github.com/labstack/echo/v4"
+)
+
+// ValidateUser determines whether or not a username exists in the database. If an error occurs during the lookup or
+// the user doesn't exist then the appropriate response will be sent to the caller and an error will be returned.
+func (s Server) ValidateUser(ctx echo.Context, username string) error {
+	exists, err := db.UserExists(ctx.Request().Context(), s.GORMDB, username)
+	if err != nil {
+		model.Error(ctx, err.Error(), http.StatusInternalServerError)
+		return err
+	}
+	if !exists {
+		msg := fmt.Sprintf("user %s does not exist", username)
+		model.Error(ctx, msg, http.StatusNotFound)
+		return errors.New(msg)
+	}
+	return nil
+}

--- a/internal/controllers/util.go
+++ b/internal/controllers/util.go
@@ -15,12 +15,18 @@ import (
 func (s Server) ValidateUser(ctx echo.Context, username string) error {
 	exists, err := db.UserExists(ctx.Request().Context(), s.GORMDB, username)
 	if err != nil {
-		model.Error(ctx, err.Error(), http.StatusInternalServerError)
+		sendErr := model.Error(ctx, err.Error(), http.StatusInternalServerError)
+		if sendErr != nil {
+			ctx.Logger().Errorf("unable to send response: %s", sendErr.Error())
+		}
 		return err
 	}
 	if !exists {
 		msg := fmt.Sprintf("user %s does not exist", username)
-		model.Error(ctx, msg, http.StatusNotFound)
+		sendErr := model.Error(ctx, msg, http.StatusNotFound)
+		if sendErr != nil {
+			ctx.Logger().Errorf("unable to send response: %s", sendErr.Error())
+		}
 		return errors.New(msg)
 	}
 	return nil

--- a/internal/db/user.go
+++ b/internal/db/user.go
@@ -28,3 +28,18 @@ func GetUser(ctx context.Context, db *gorm.DB, username string) (*model.User, er
 
 	return &user, nil
 }
+
+// UserExists determines whether or not the user exists in the database.
+func UserExists(ctx context.Context, db *gorm.DB, username string) (bool, error) {
+	wrapMsg := "unable to determine whether user exists"
+	var err error
+
+	var user model.User
+	err = db.WithContext(ctx).Debug().Where("username = ?", username).First(&user).Error
+	if err == gorm.ErrRecordNotFound {
+		return false, nil
+	} else if err != nil {
+		return false, errors.Wrap(err, wrapMsg)
+	}
+	return true, nil
+}

--- a/internal/model/update.go
+++ b/internal/model/update.go
@@ -26,4 +26,5 @@ type Update struct {
 	UpdateOperationID *string      `gorm:"type:uuid;not null" json:"-"`
 	ResourceTypeID    *string      `gorm:"type:uuid;not null" json:"-"`
 	ResourceType      ResourceType `json:"resource_types"`
+	User              User         `json:"user"`
 }

--- a/internal/model/update.go
+++ b/internal/model/update.go
@@ -26,5 +26,6 @@ type Update struct {
 	UpdateOperationID *string      `gorm:"type:uuid;not null" json:"-"`
 	ResourceTypeID    *string      `gorm:"type:uuid;not null" json:"-"`
 	ResourceType      ResourceType `json:"resource_types"`
+	UserID            *string      `gorm:"type:uuid" json:"-"`
 	User              User         `json:"user"`
 }

--- a/migrations/000006_updates_users_fk.down.sql
+++ b/migrations/000006_updates_users_fk.down.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+SET search_path = public, pg_catalog;
+
+ALTER TABLE IF EXISTS updates DROP COLUMN IF EXISTS user_id;
+
+COMMIT;

--- a/migrations/000006_updates_users_fk.up.sql
+++ b/migrations/000006_updates_users_fk.up.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+SET search_path = public, pg_catalog;
+
+ALTER TABLE IF EXISTS updates ADD COLUMN IF NOT EXISTS user_id uuid REFERENCES users(id);
+
+COMMIT;

--- a/server/router.go
+++ b/server/router.go
@@ -98,7 +98,7 @@ func RegisterHandlers(s controllers.Server) {
 	usages := v1.Group("/usages")
 	usages.GET("/:username", s.GetAllUsageOfUser)
 	usages.POST("", s.AddUsages)
-	usages.GET("/updates", s.GetAllUsageUpdatesForUser)
+	usages.GET("/:username/updates", s.GetAllUsageUpdatesForUser)
 
 	users := v1.Group("/users")
 	registerUserEndpoints(users, &s)

--- a/server/router.go
+++ b/server/router.go
@@ -98,6 +98,7 @@ func RegisterHandlers(s controllers.Server) {
 	usages := v1.Group("/usages")
 	usages.GET("/:username", s.GetAllUsageOfUser)
 	usages.POST("", s.AddUsages)
+	usages.GET("/updates", s.GetAllUsageUpdatesForUser)
 
 	users := v1.Group("/users")
 	registerUserEndpoints(users, &s)


### PR DESCRIPTION
Associates an update in QMS with a user and allows for querying for a user's updates.

The endpoints for querying the updates may need more work, but they shouldn't prevent QMS from functioning if something goes wrong.

The new user_id column is nullable since we're working on getting the data scrubbed and there's currently no way to figure out which user an update applies to. It can be made not nullable in a future update after the data scrubbing has been completed and the table is populated with data that contains the user_id information.