### PR TITLE
CORE-1800: make the last_modified_at field for quota and usage record…

### DIFF
--- a/internal/model/quota.go
+++ b/internal/model/quota.go
@@ -9,7 +9,7 @@ type Quota struct {
 	UserPlanID     *string      `gorm:"type:uuid;not null" json:"-"`
 	ResourceTypeID *string      `gorm:"type:uuid;not null" json:"-"`
 	ResourceType   ResourceType `json:"resource_type"`
-	LastModifiedAt *time.Time   `json:"last_modified_at"`
+	LastModifiedAt *time.Time   `gorm:"->" json:"last_modified_at"`
 }
 
 // TableName specifies the table name to use the database.

--- a/internal/model/usage.go
+++ b/internal/model/usage.go
@@ -9,5 +9,5 @@ type Usage struct {
 	UserPlanID     *string      `gorm:"type:uuid;not null;index:usage_userplan_resourcetype,unique" json:"-"`
 	ResourceTypeID *string      `gorm:"type:uuid;not null;index:usage_userplan_resourcetype,unique" json:"-"`
 	ResourceType   ResourceType `json:"resource_type"`
-	LastModifiedAt *time.Time   `json:"last_modified_at"`
+	LastModifiedAt *time.Time   `gorm:"->" json:"last_modified_at"`
 }


### PR DESCRIPTION
…s read-only

I'd planned on testing updates once QMS was deployed in QA, and...well...it didn't work. It turned out that I have to explicitly mark the field as read-only. This PR does that.
