### PR TITLE
CORE-1805: Bulk Subscriptions Endpoint

### DIFF
--- a/cmd/fix-usernames/main.go
+++ b/cmd/fix-usernames/main.go
@@ -279,7 +279,7 @@ func fixUsername(ctx context.Context, tx *gorm.DB, newUsername string, usernameS
 			return errors.Wrapf(err, "unable to subscribe %s to the default plan", newUser.Username)
 		}
 	} else {
-		plan := &oldSubscription.Plan
+		plan := oldSubscription.Plan
 		newSubscription, err = db.SubscribeUserToPlan(ctx, tx, newUser, plan)
 		if err != nil {
 			return errors.Wrapf(err, "unable to subscribe %s to the %s plan", newUser.Username, plan.Name)

--- a/internal/controllers/subscriptions.go
+++ b/internal/controllers/subscriptions.go
@@ -1,0 +1,20 @@
+package controllers
+
+import "github.com/labstack/echo/v4"
+
+// AddSubscriptions creates the subscriptions described in the request body.
+//
+// swagger:route POST /v1/subscriptions subscriptions addSubscriptions
+//
+// Add Subscriptions
+//
+// Creates the subscriptions described in the request body.
+//
+// Responses:
+//
+//	200: subscriptionsResponse
+func (s Server) AddSubscriptions(ctx echo.Context) error {
+	var err error
+
+	return err
+}

--- a/internal/controllers/subscriptions.go
+++ b/internal/controllers/subscriptions.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/cyverse-de/notifications/query"
 	"github.com/cyverse/QMS/internal/db"
 	"github.com/cyverse/QMS/internal/model"
+	"github.com/cyverse/QMS/internal/query"
 	"github.com/labstack/echo/v4"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"

--- a/internal/controllers/subscriptions.go
+++ b/internal/controllers/subscriptions.go
@@ -1,6 +1,95 @@
 package controllers
 
-import "github.com/labstack/echo/v4"
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/cyverse/QMS/internal/db"
+	"github.com/cyverse/QMS/internal/model"
+	"github.com/labstack/echo/v4"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
+)
+
+// SubscriptionAdder encapsulates the addition of subscriptions with a cached index of subscription plans.
+type SubscriptionAdder struct {
+	log         *logrus.Entry
+	ctx         context.Context
+	plansByName map[string]*model.Plan
+}
+
+// NewSubscriptionAdder creates a new SubscriptionAdder instance.
+func NewSubscriptionAdder(log *logrus.Entry, ctx context.Context, tx *gorm.DB) (*SubscriptionAdder, error) {
+	plansByName, err := db.GetPlansByName(ctx, tx)
+	if err != nil {
+		err = errors.Wrap(err, "unable to load subscription plan information")
+		return nil, err
+	}
+
+	subscriptionAdder := &SubscriptionAdder{
+		log:         log,
+		ctx:         ctx,
+		plansByName: plansByName,
+	}
+	return subscriptionAdder, nil
+}
+
+// subscriptionError returns an error record indicating that a subscription could not be created. This is just a
+// utility function to remove some cumbersome code in AddSubscription.
+func (sa *SubscriptionAdder) subscriptionError(f string, args ...any) *model.SubscriptionResponse {
+	msg := fmt.Sprintf(f, args...)
+	return &model.SubscriptionResponse{FailureReason: &msg}
+}
+
+// AddSubscription subscribes a user to a subscription plan.
+func (sa *SubscriptionAdder) AddSubscription(tx *gorm.DB, username, planName *string) *model.SubscriptionResponse {
+	if username == nil || *username == "" {
+		return sa.subscriptionError("no username provied in request")
+	}
+	if planName == nil || *planName == "" {
+		return sa.subscriptionError("no plan name provided in request")
+	}
+
+	// Look up the plan information.
+	plan, ok := sa.plansByName[*planName]
+	if !ok || plan == nil {
+		return sa.subscriptionError("plan does not exist: %s", *planName)
+	}
+
+	// Add some fields to the logger.
+	var log = sa.log.WithFields(
+		logrus.Fields{
+			"username": *username,
+			"planName": *planName,
+		},
+	)
+	log.Tracef("adding a new subscription")
+
+	// Get the user information.
+	user, err := db.GetUser(sa.ctx, tx, *username)
+	if err != nil {
+		log.Error(err)
+		return sa.subscriptionError(err.Error())
+	}
+
+	// Add the subscription.
+	sub, err := db.SubscribeUserToPlan(sa.ctx, tx, user, plan)
+	if err != nil {
+		log.Error(err)
+		return sa.subscriptionError(err.Error())
+	}
+
+	// Load the subscription details.
+	sub, err = db.GetUserPlanDetails(sa.ctx, tx, *sub.ID)
+	if err != nil {
+		log.Error(err)
+		return sa.subscriptionError(err.Error())
+	}
+
+	return model.SubscriptionResponseFromUserPlan(sub)
+}
 
 // AddSubscriptions creates the subscriptions described in the request body.
 //
@@ -16,5 +105,38 @@ import "github.com/labstack/echo/v4"
 func (s Server) AddSubscriptions(ctx echo.Context) error {
 	var err error
 
-	return err
+	// Initialize the context for the endpoint.
+	var log = log.WithField("context", "add-subscriptions")
+	var context = ctx.Request().Context()
+
+	// Parse the request body.
+	var body model.SubscriptionRequests
+	err = ctx.Bind(&body)
+	if err != nil {
+		msg := fmt.Sprintf("invalid request body: %s", err)
+		log.Error(msg)
+		return model.Error(ctx, msg, http.StatusBadRequest)
+	}
+
+	// Create a new subscription adder.
+	subscriptionAdder, err := NewSubscriptionAdder(log, context, s.GORMDB)
+	if err != nil {
+		log.Error(err)
+		return model.Error(ctx, err.Error(), http.StatusInternalServerError)
+	}
+
+	// Add a separate subscription for each subscription request in the request body.
+	response := make([]*model.SubscriptionResponse, len(body.Subscriptions))
+	for i, subscriptionRequest := range body.Subscriptions {
+		_ = s.GORMDB.Transaction(func(tx *gorm.DB) error {
+			response[i] = subscriptionAdder.AddSubscription(
+				tx,
+				subscriptionRequest.Username,
+				subscriptionRequest.PlanName,
+			)
+			return nil
+		})
+	}
+
+	return model.Success(ctx, response, http.StatusOK)
 }

--- a/internal/controllers/subscriptions.go
+++ b/internal/controllers/subscriptions.go
@@ -6,7 +6,7 @@ import "github.com/labstack/echo/v4"
 //
 // swagger:route POST /v1/subscriptions subscriptions addSubscriptions
 //
-// Add Subscriptions
+// # Add Subscriptions
 //
 // Creates the subscriptions described in the request body.
 //

--- a/internal/controllers/subscriptions.go
+++ b/internal/controllers/subscriptions.go
@@ -52,7 +52,7 @@ func (sa *SubscriptionAdder) subscriptionError(f string, args ...any) *model.Sub
 // AddSubscription subscribes a user to a subscription plan.
 func (sa *SubscriptionAdder) AddSubscription(tx *gorm.DB, username, planName *string) *model.SubscriptionResponse {
 	if username == nil || *username == "" {
-		return sa.subscriptionError("no username provied in request")
+		return sa.subscriptionError("no username provided in request")
 	}
 	if planName == nil || *planName == "" {
 		return sa.subscriptionError("no plan name provided in request")

--- a/internal/db/plan.go
+++ b/internal/db/plan.go
@@ -86,3 +86,19 @@ func GetDefaultQuotaForPlan(ctx context.Context, db *gorm.DB, planID string) ([]
 
 	return planQuotaDefaults, nil
 }
+
+// GetPlansByName builds a map from plan name to plan details.
+func GetPlansByName(ctx context.Context, db *gorm.DB) (map[string]*model.Plan, error) {
+	plans, err := ListPlans(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build the map from the plan name to the plan details.
+	result := make(map[string]*model.Plan)
+	for _, plan := range plans {
+		result[plan.Name] = plan
+	}
+
+	return result, nil
+}

--- a/internal/model/plan.go
+++ b/internal/model/plan.go
@@ -91,7 +91,7 @@ type UserPlan struct {
 	// The quotas associated with the subscription
 	Quotas []Quota `json:"quotas,omitempty"`
 
-	// The recorded usage amounts associated witht he subscription
+	// The recorded usage amounts associated with the subscription
 	Usages []Usage `json:"usages,omitempty"`
 }
 

--- a/internal/model/plan.go
+++ b/internal/model/plan.go
@@ -11,18 +11,18 @@ type Plan struct {
 	// The plan identifier
 	//
 	// readOnly: true
-	ID *string `gorm:"type:uuid;default:uuid_generate_v1()" json:"id"`
+	ID *string `gorm:"type:uuid;default:uuid_generate_v1()" json:"id,omitempty"`
 
 	// The plan name
-	Name string `gorm:"not null;unique" json:"name"`
+	Name string `gorm:"not null;unique" json:"name,omitempty"`
 
 	// A brief description of the plan
 	//
 	// required: true
-	Description string `gorm:"not null" json:"description"`
+	Description string `gorm:"not null" json:"description,omitempty"`
 
 	// The default quota values associated with the plan
-	PlanQuotaDefaults []PlanQuotaDefault `json:"plan_quota_defaults"`
+	PlanQuotaDefaults []PlanQuotaDefault `json:"plan_quota_defaults,omitempty"`
 }
 
 // GetDefaultQuotaValue returns the default quota value associated with the resource type with the given name.
@@ -42,7 +42,7 @@ type PlanQuotaDefault struct {
 	// The plan quota default identifier
 	//
 	// readOnly: true
-	ID *string `gorm:"type:uuid;default:uuid_generate_v1()" json:"id"`
+	ID *string `gorm:"type:uuid;default:uuid_generate_v1()" json:"id,omitempty"`
 
 	// The plan ID
 	PlanID *string `gorm:"type:uuid;not null" json:"-"`
@@ -50,7 +50,7 @@ type PlanQuotaDefault struct {
 	// The default quota value
 	//
 	// required: true
-	QuotaValue float64 `gorm:"not null" json:"quota_value"`
+	QuotaValue float64 `gorm:"not null" json:"quota_value,omitempty"`
 
 	// The resource type ID
 	ResourceTypeID *string `gorm:"type:uuid;not null" json:"-"`
@@ -58,7 +58,7 @@ type PlanQuotaDefault struct {
 	// The resource type
 	//
 	// required: true
-	ResourceType ResourceType `json:"resource_type"`
+	ResourceType ResourceType `json:"resource_type,omitempty"`
 }
 
 // UserPlan define the structure for the API User plans.
@@ -68,31 +68,31 @@ type UserPlan struct {
 	// The subscription identifier
 	//
 	// readOnly: true
-	ID *string `gorm:"type:uuid;default:uuid_generate_v1()" json:"id"`
+	ID *string `gorm:"type:uuid;default:uuid_generate_v1()" json:"id,omitempty"`
 
 	// The date and time the subscription becomes active
-	EffectiveStartDate *time.Time `gorm:"" json:"effective_start_date"`
+	EffectiveStartDate *time.Time `gorm:"" json:"effective_start_date,omitempty"`
 
 	// The date and time the subscription expires
-	EffectiveEndDate *time.Time `gorm:"" json:"effective_end_date"`
+	EffectiveEndDate *time.Time `gorm:"" json:"effective_end_date,omitempty"`
 
 	// The user identifier
 	UserID *string `gorm:"type:uuid;not null" json:"-"`
 
 	// The user associated with the subscription
-	User User `json:"user"`
+	User *User `json:"user,omitempty"`
 
 	// The identifier of the plan associated with the subscription
 	PlanID *string `gorm:"type:uuid;not null" json:"-"`
 
 	// The plan associated with the subscription
-	Plan Plan `json:"plan"`
+	Plan *Plan `json:"plan,omitempty"`
 
 	// The quotas associated with the subscription
-	Quotas []Quota `json:"quotas"`
+	Quotas []Quota `json:"quotas,omitempty"`
 
 	// The recorded usage amounts associated witht he subscription
-	Usages []Usage `json:"usages"`
+	Usages []Usage `json:"usages,omitempty"`
 }
 
 // GetCurrentUsageValue returns the current usage value for the resource type with the given resource type ID. Be

--- a/internal/model/plan.go
+++ b/internal/model/plan.go
@@ -8,14 +8,12 @@ import (
 //
 // swagger:model
 type Plan struct {
-
 	// The plan identifier
 	//
 	// readOnly: true
 	ID *string `gorm:"type:uuid;default:uuid_generate_v1()" json:"id"`
 
 	// The plan name
-	//
 	Name string `gorm:"not null;unique" json:"name"`
 
 	// A brief description of the plan
@@ -29,7 +27,6 @@ type Plan struct {
 
 // PlanQuotaDefault define the structure for an Api Plan and Quota.
 type PlanQuotaDefault struct {
-
 	// The plan quota default identifier
 	//
 	// readOnly: true
@@ -53,16 +50,37 @@ type PlanQuotaDefault struct {
 }
 
 // UserPlan define the structure for the API User plans.
+//
+// swagger:model
 type UserPlan struct {
-	ID                 *string    `gorm:"type:uuid;default:uuid_generate_v1()" json:"id"`
+	// The subscription identifier
+	//
+	// readOnly: true
+	ID *string `gorm:"type:uuid;default:uuid_generate_v1()" json:"id"`
+
+	// The date and time the subscription becomes active
 	EffectiveStartDate *time.Time `gorm:"" json:"effective_start_date"`
-	EffectiveEndDate   *time.Time `gorm:"" json:"effective_end_date"`
-	UserID             *string    `gorm:"type:uuid;not null" json:"-"`
-	User               User       `json:"user"`
-	PlanID             *string    `gorm:"type:uuid;not null" json:"-"`
-	Plan               Plan       `json:"plan"`
-	Quotas             []Quota    `json:"quotas"`
-	Usages             []Usage    `json:"usages"`
+
+	// The date and time the subscription expires
+	EffectiveEndDate *time.Time `gorm:"" json:"effective_end_date"`
+
+	// The user identifier
+	UserID *string `gorm:"type:uuid;not null" json:"-"`
+
+	// The user associated with the subscription
+	User User `json:"user"`
+
+	// The identifier of the plan associated with the subscription
+	PlanID *string `gorm:"type:uuid;not null" json:"-"`
+
+	// The plan associated with the subscription
+	Plan Plan `json:"plan"`
+
+	// The quotas associated with the subscription
+	Quotas []Quota `json:"quotas"`
+
+	// The recorded usage amounts associated witht he subscription
+	Usages []Usage `json:"usages"`
 }
 
 // GetCurrentUsageValue returns the current usage value for the resource type with the given resource type ID. Be

--- a/internal/model/plan.go
+++ b/internal/model/plan.go
@@ -25,6 +25,18 @@ type Plan struct {
 	PlanQuotaDefaults []PlanQuotaDefault `json:"plan_quota_defaults"`
 }
 
+// GetDefaultQuotaValue returns the default quota value associated with the resource type with the given name.
+func (p *Plan) GetDefaultQuotaValue(resourcetypeName string) float64 {
+	var value float64
+	for _, quotaDefault := range p.PlanQuotaDefaults {
+		if quotaDefault.ResourceType.Name == resourcetypeName {
+			value = quotaDefault.QuotaValue
+			break
+		}
+	}
+	return value
+}
+
 // PlanQuotaDefault define the structure for an Api Plan and Quota.
 type PlanQuotaDefault struct {
 	// The plan quota default identifier

--- a/internal/model/quota.go
+++ b/internal/model/quota.go
@@ -9,10 +9,10 @@ type Quota struct {
 	// The quota identifier
 	//
 	// readOnly: true
-	ID *string `gorm:"type:uuid;default:uuid_generate_v1()" json:"id"`
+	ID *string `gorm:"type:uuid;default:uuid_generate_v1()" json:"id,omitempty"`
 
 	// The resource usage limit
-	Quota float64 `json:"quota"`
+	Quota float64 `json:"quota,omitempty"`
 
 	// The user plan ID
 	UserPlanID *string `gorm:"type:uuid;not null" json:"-"`
@@ -21,10 +21,10 @@ type Quota struct {
 	ResourceTypeID *string `gorm:"type:uuid;not null" json:"-"`
 
 	// The resource type associated with this quota
-	ResourceType ResourceType `json:"resource_type"`
+	ResourceType ResourceType `json:"resource_type,omitempty"`
 
 	// The date and time the quota was last modified
-	LastModifiedAt *time.Time `gorm:"->" json:"last_modified_at"`
+	LastModifiedAt *time.Time `gorm:"->" json:"last_modified_at,omitempty"`
 }
 
 // TableName specifies the table name to use the database.

--- a/internal/model/quota.go
+++ b/internal/model/quota.go
@@ -2,14 +2,29 @@ package model
 
 import "time"
 
-// Quota define the structure for an Api Plan and Quota.
+// Quota represents a resource usage limit associated with a subscription.
+//
+// swagger:model
 type Quota struct {
-	ID             *string      `gorm:"type:uuid;default:uuid_generate_v1()" json:"id"`
-	Quota          float64      `json:"quota"`
-	UserPlanID     *string      `gorm:"type:uuid;not null" json:"-"`
-	ResourceTypeID *string      `gorm:"type:uuid;not null" json:"-"`
-	ResourceType   ResourceType `json:"resource_type"`
-	LastModifiedAt *time.Time   `gorm:"->" json:"last_modified_at"`
+	// The quota identifier
+	//
+	// readOnly: true
+	ID *string `gorm:"type:uuid;default:uuid_generate_v1()" json:"id"`
+
+	// The resource usage limit
+	Quota float64 `json:"quota"`
+
+	// The user plan ID
+	UserPlanID *string `gorm:"type:uuid;not null" json:"-"`
+
+	// The resource type ID
+	ResourceTypeID *string `gorm:"type:uuid;not null" json:"-"`
+
+	// The resource type associated with this quota
+	ResourceType ResourceType `json:"resource_type"`
+
+	// The date and time the quota was last modified
+	LastModifiedAt *time.Time `gorm:"->" json:"last_modified_at"`
 }
 
 // TableName specifies the table name to use the database.

--- a/internal/model/resource.go
+++ b/internal/model/resource.go
@@ -1,5 +1,10 @@
 package model
 
+const (
+	RESOURCE_TYPE_CPU_HOURS = "cpu.hours"
+	RESOURCE_TYPE_DATA_SIZE = "data.size"
+)
+
 // ResourceType defines the structure for ResourceTypes.
 //
 // swagger:model

--- a/internal/model/resource.go
+++ b/internal/model/resource.go
@@ -12,13 +12,13 @@ type ResourceType struct {
 	// The resource type ID
 	//
 	// readOnly: true
-	ID *string `gorm:"type:uuid;default:uuid_generate_v1()" json:"id"`
+	ID *string `gorm:"type:uuid;default:uuid_generate_v1()" json:"id,omitempty"`
 	// The resource type name
 	//
 	// required: true
-	Name string `gorm:"not null;unique" json:"name"`
+	Name string `gorm:"not null;unique" json:"name,omitempty"`
 	// The unit of measure used for the resource type
 	//
 	// required: true
-	Unit string `gorm:"not null;unique" json:"unit"`
+	Unit string `gorm:"not null;unique" json:"unit,omitempty"`
 }

--- a/internal/model/subscriptions.go
+++ b/internal/model/subscriptions.go
@@ -33,11 +33,15 @@ type SubscriptionResponse struct {
 
 	// The reason the subscription couldn't be created if an error occurred.
 	FailureReason *string `json:"failure_reason"`
+
+	// True if the subscription was just created.
+	NewSubscription bool `json:"new_subscription"`
 }
 
 // SubscriptionResponseFromUserPlan converts a user plan to a subscription response.
-func SubscriptionResponseFromUserPlan(userPlan *UserPlan) *SubscriptionResponse {
+func SubscriptionResponseFromUserPlan(userPlan *UserPlan, newSubscription bool) *SubscriptionResponse {
 	var resp SubscriptionResponse
 	resp.UserPlan = *userPlan
+	resp.NewSubscription = newSubscription
 	return &resp
 }

--- a/internal/model/subscriptions.go
+++ b/internal/model/subscriptions.go
@@ -34,3 +34,10 @@ type SubscriptionResponse struct {
 	// The reason the subscription couldn't be created if an error occurred.
 	FailureReason *string `json:"failure_reason"`
 }
+
+// SubscriptionResponseFromUserPlan converts a user plan to a subscription response.
+func SubscriptionResponseFromUserPlan(userPlan *UserPlan) *SubscriptionResponse {
+	var resp SubscriptionResponse
+	resp.UserPlan = *userPlan
+	return &resp
+}

--- a/internal/model/subscriptions.go
+++ b/internal/model/subscriptions.go
@@ -15,7 +15,7 @@ type SubscriptionRequest struct {
 	PlanName *string `json:"plan_name"`
 }
 
-//	SubscriptionRequests represents a list of subscription requests.
+// SubscriptionRequests represents a list of subscription requests.
 //
 // swagger: model
 type SubscriptionRequests struct {

--- a/internal/model/subscriptions.go
+++ b/internal/model/subscriptions.go
@@ -32,7 +32,7 @@ type SubscriptionResponse struct {
 	UserPlan
 
 	// The reason the subscription couldn't be created if an error occurred.
-	FailureReason *string `json:"failure_reason"`
+	FailureReason *string `json:"failure_reason,omitempty"`
 
 	// True if the subscription was just created.
 	NewSubscription bool `json:"new_subscription"`

--- a/internal/model/subscriptions.go
+++ b/internal/model/subscriptions.go
@@ -1,0 +1,36 @@
+package model
+
+// SubscriptionRequest represents a request for a single subscription.
+//
+// swagger: model
+type SubscriptionRequest struct {
+	// The username to associate with the subscription
+	//
+	// required: true
+	Username *string `json:"username"`
+
+	// The name of the plan associated with the subscription
+	//
+	// required: true
+	PlanName *string `json:"plan_name"`
+}
+
+//	SubscriptionRequests represents a list of subscription requests.
+//
+// swagger: model
+type SubscriptionRequests struct {
+	// The list of subscriptions to create
+	//
+	// required: true
+	Subscriptions []SubscriptionRequest `json:"subscriptions"`
+}
+
+// SubscriptionResponse represents a response to a request for a single subscription.
+//
+// swagger: model
+type SubscriptionResponse struct {
+	UserPlan
+
+	// The reason the subscription couldn't be created if an error occurred.
+	FailureReason *string `json:"failure_reason"`
+}

--- a/internal/model/usage.go
+++ b/internal/model/usage.go
@@ -3,11 +3,26 @@ package model
 import "time"
 
 // Usage define the structure for API Usages.
+//
+// swagger:model
 type Usage struct {
-	ID             *string      `gorm:"type:uuid;default:uuid_generate_v1()" json:"id"`
-	Usage          float64      `gorm:"not null" json:"usage"`
-	UserPlanID     *string      `gorm:"type:uuid;not null;index:usage_userplan_resourcetype,unique" json:"-"`
-	ResourceTypeID *string      `gorm:"type:uuid;not null;index:usage_userplan_resourcetype,unique" json:"-"`
-	ResourceType   ResourceType `json:"resource_type"`
-	LastModifiedAt *time.Time   `gorm:"->" json:"last_modified_at"`
+	// The usage record identifier
+	//
+	// readOnly: true
+	ID *string `gorm:"type:uuid;default:uuid_generate_v1()" json:"id"`
+
+	// The usage amount
+	Usage float64 `gorm:"not null" json:"usage"`
+
+	// The subscription identifier
+	UserPlanID *string `gorm:"type:uuid;not null;index:usage_userplan_resourcetype,unique" json:"-"`
+
+	// The resource type identifier
+	ResourceTypeID *string `gorm:"type:uuid;not null;index:usage_userplan_resourcetype,unique" json:"-"`
+
+	// The resource type associated with the usage amount
+	ResourceType ResourceType `json:"resource_type"`
+
+	// The date and time the usage value was last modified
+	LastModifiedAt *time.Time `gorm:"->" json:"last_modified_at"`
 }

--- a/internal/model/usage.go
+++ b/internal/model/usage.go
@@ -9,10 +9,10 @@ type Usage struct {
 	// The usage record identifier
 	//
 	// readOnly: true
-	ID *string `gorm:"type:uuid;default:uuid_generate_v1()" json:"id"`
+	ID *string `gorm:"type:uuid;default:uuid_generate_v1()" json:"id,omitempty"`
 
 	// The usage amount
-	Usage float64 `gorm:"not null" json:"usage"`
+	Usage float64 `gorm:"not null" json:"usage,omitempty"`
 
 	// The subscription identifier
 	UserPlanID *string `gorm:"type:uuid;not null;index:usage_userplan_resourcetype,unique" json:"-"`
@@ -21,8 +21,8 @@ type Usage struct {
 	ResourceTypeID *string `gorm:"type:uuid;not null;index:usage_userplan_resourcetype,unique" json:"-"`
 
 	// The resource type associated with the usage amount
-	ResourceType ResourceType `json:"resource_type"`
+	ResourceType ResourceType `json:"resource_type,omitempty"`
 
 	// The date and time the usage value was last modified
-	LastModifiedAt *time.Time `gorm:"->" json:"last_modified_at"`
+	LastModifiedAt *time.Time `gorm:"->" json:"last_modified_at,omitempty"`
 }

--- a/internal/model/user.go
+++ b/internal/model/user.go
@@ -9,11 +9,11 @@ type User struct {
 	//
 	// in: path
 	// required: true
-	ID *string `gorm:"type:uuid;default:uuid_generate_v1()" json:"id"`
+	ID *string `gorm:"type:uuid;default:uuid_generate_v1()" json:"id,omitempty"`
 
 	// The username
 	//
 	// in: path
 	// required: true
-	Username string `gorm:"not null;unique" json:"username"`
+	Username string `gorm:"not null;unique" json:"username,omitempty"`
 }

--- a/internal/query/main.go
+++ b/internal/query/main.go
@@ -1,0 +1,50 @@
+package query
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/go-playground/validator/v10"
+	"github.com/labstack/echo/v4"
+	"github.com/pkg/errors"
+)
+
+// Define a single validator to do all of the validations for us.
+var v = validator.New()
+
+// ValidatedQueryParam extracts a query parameter and validates it.
+func ValidatedQueryParam(ctx echo.Context, name, validationTag string) (string, error) {
+	value := ctx.QueryParam(name)
+
+	// Validate the value.
+	if err := v.Var(value, validationTag); err != nil {
+		return "", err
+	}
+
+	return value, nil
+}
+
+// ValidateBooleanQueryParam extracts a Boolean query parameter and validates it.
+func ValidateBooleanQueryParam(ctx echo.Context, name string, defaultValue *bool) (bool, error) {
+	errMsg := fmt.Sprintf("invalid query parameter: %s", name)
+	value := ctx.QueryParam(name)
+
+	// Assume that the parameter is required if there's no default.
+	if defaultValue == nil {
+		if err := v.Var(value, "required"); err != nil {
+			return false, fmt.Errorf("missing required query parameter: %s", name)
+		}
+	}
+
+	// If no value was provided at this point then the prameter is optional; return the default value.
+	if value == "" {
+		return *defaultValue, nil
+	}
+
+	// Parse the parameter value and return the result.
+	result, err := strconv.ParseBool(value)
+	if err != nil {
+		return false, errors.Wrap(err, errMsg)
+	}
+	return result, nil
+}

--- a/internal/swagger/swagger.go
+++ b/internal/swagger/swagger.go
@@ -130,6 +130,13 @@ type SuccessMessageResponseWrapoper struct {
 // swagger:parameters addSubscriptions
 type AddSubscriptionsParameters struct {
 
+	// If `true` or unspecified, the new subscriptions will be created regardless of the user's current subscription
+	// level. If `false`, the subscription will only be created if the user's subscription level is lower than the
+	// requested subscription level.
+	//
+	// in: query
+	Force *bool `json:"force"`
+
 	// The subscriptions to add
 	//
 	// in: body

--- a/internal/swagger/swagger.go
+++ b/internal/swagger/swagger.go
@@ -2,15 +2,15 @@
 //
 // Documentation of the QMS Api
 //
-//     Schemes: http
-//     BasePath: /
-//     Version: V1
+//	Schemes: http
+//	BasePath: /
+//	Version: V1
 //
-//     Consumes:
-//     - application/json
+//	Consumes:
+//	- application/json
 //
-//     Produces:
-//     - application/json
+//	Produces:
+//	- application/json
 //
 // swagger:meta
 package swagger
@@ -122,6 +122,31 @@ type SuccessMessageResponseWrapoper struct {
 
 		// The success message.
 		Result string `json:"result"`
+	}
+}
+
+// Parameters for the endpoint used to add multiple subscriptions.
+//
+// swagger:parameters addSubscriptions
+type AddSubscriptionsParameters struct {
+
+	// The subscriptions to add
+	//
+	// in: body
+	Body model.SubscriptionRequests
+}
+
+// Subscriptions Response
+//
+// swagger:response subscriptionsResponse
+type SubscriptionsResponse struct {
+
+	// in:body
+	Body struct {
+		ResponseBodyWrapper
+
+		// The list of subscription responses
+		Result []model.SubscriptionResponse
 	}
 }
 

--- a/server/router.go
+++ b/server/router.go
@@ -95,6 +95,10 @@ func RegisterHandlers(s controllers.Server) {
 	plans := v1.Group("/plans")
 	registerPlanEndpoints(plans, &s)
 
+	subscriptions := v1.Group("/subscriptions")
+	subscriptions.POST("", s.AddSubscriptions)
+	subscriptions.POST("/", s.AddSubscriptions)
+
 	usages := v1.Group("/usages")
 	usages.GET("/:username", s.GetAllUsageOfUser)
 	usages.POST("", s.AddUsages)


### PR DESCRIPTION
This PR adds an endpoint that can be used to create multiple subscriptions at once. Here are the Swagger docs:

![image](https://user-images.githubusercontent.com/415143/200645100-d0a93ba1-ddfc-41c2-b603-e715e780f138.png)

Here's an example API call:

```
$ curl -sH "$AUTH_HEADER" "http://localhost:9000/v1/subscriptions?force=false" -H "Content-Type: application/json" -d '{"subscriptions":[{"username":"nobody","plan_name":"foo"},{"username":"ipcdev","plan_name":"bar"},{},{"username":"ipctest"},{"username":"sarahr","plan_name":"Pro"}]}' | jq
{
  "result": [
    {
      "failure_reason": "plan does not exist: foo",
      "new_subscription": false
    },
    {
      "failure_reason": "plan does not exist: bar",
      "new_subscription": false
    },
    {
      "failure_reason": "no username provided in request",
      "new_subscription": false
    },
    {
      "failure_reason": "no plan name provided in request",
      "new_subscription": false
    },
    {
      "id": "e82cdba0-5fb1-11ed-9a44-ebd74426b32e",
      "effective_start_date": "2022-11-08T15:08:42.745411-07:00",
      "effective_end_date": "2023-11-08T15:08:42.745411-07:00",
      "user": {
        "id": "4ec99c70-5edd-11ed-bd9f-ac87a33625be",
        "username": "sarahr"
      },
      "plan": {
        "id": "cdf7ac7a-98dc-11ec-bbe3-406c8f3e9cbb",
        "name": "Pro",
        "description": "Professional plan",
        "plan_quota_defaults": [
          {
            "id": "7efddabe-47d6-401c-b857-d08361397fcf",
            "quota_value": 2000,
            "resource_type": {
              "id": "99e3bc7e-950a-11ec-84a4-406c8f3e9cbb",
              "name": "cpu.hours",
              "unit": "cpu hours"
            }
          },
          {
            "id": "2c39ff2f-2ec7-4ac8-a10e-79fd82b39c09",
            "quota_value": 3298534883328,
            "resource_type": {
              "id": "99e3f91e-950a-11ec-84a4-406c8f3e9cbb",
              "name": "data.size",
              "unit": "bytes"
            }
          }
        ]
      },
      "quotas": [
        {
          "id": "e82ced8e-5fb1-11ed-9a44-ebd74426b32e",
          "quota": 2000,
          "resource_type": {
            "id": "99e3bc7e-950a-11ec-84a4-406c8f3e9cbb",
            "name": "cpu.hours",
            "unit": "cpu hours"
          },
          "last_modified_at": "2022-11-08T15:08:42.744945-07:00"
        },
        {
          "id": "e82ceee2-5fb1-11ed-9a44-ebd74426b32e",
          "quota": 3298534883328,
          "resource_type": {
            "id": "99e3f91e-950a-11ec-84a4-406c8f3e9cbb",
            "name": "data.size",
            "unit": "bytes"
          },
          "last_modified_at": "2022-11-08T15:08:42.744945-07:00"
        }
      ],
      "new_subscription": false
    }
  ],
  "status": "OK"
}
```
