### PR TITLE
CORE-1807: added the subscription listing endpoint.

### DIFF
--- a/internal/controllers/subscriptions.go
+++ b/internal/controllers/subscriptions.go
@@ -226,6 +226,7 @@ func (s Server) ListSubscriptions(ctx echo.Context) error {
 		log.Error(err)
 		return model.Error(ctx, err.Error(), http.StatusBadRequest)
 	}
+	search := ctx.QueryParam("search")
 
 	// Determine the sort field to pass to the database.
 	dbSortFieldFor := map[string]string{
@@ -248,6 +249,7 @@ func (s Server) ListSubscriptions(ctx echo.Context) error {
 			Limit:     int(limit),
 			SortField: dbSortField,
 			SortOrder: sortOrder,
+			Search:    search,
 		}
 		subscriptions, err = db.ListUserPlans(context, tx, params)
 		return err

--- a/internal/controllers/subscriptions.go
+++ b/internal/controllers/subscriptions.go
@@ -221,7 +221,7 @@ func (s Server) ListSubscriptions(ctx echo.Context) error {
 		log.Error(err)
 		return model.Error(ctx, err.Error(), http.StatusBadRequest)
 	}
-	sortOrder, err := query.ValidateSortOrder(ctx)
+	sortDir, err := query.ValidateSortDir(ctx)
 	if err != nil {
 		log.Error(err)
 		return model.Error(ctx, err.Error(), http.StatusBadRequest)
@@ -249,7 +249,7 @@ func (s Server) ListSubscriptions(ctx echo.Context) error {
 			Offset:    int(offset),
 			Limit:     int(limit),
 			SortField: dbSortField,
-			SortOrder: sortOrder,
+			SortDir:   sortDir,
 			Search:    search,
 		}
 		subscriptions, count, err = db.ListUserPlans(context, tx, params)

--- a/internal/controllers/subscriptions.go
+++ b/internal/controllers/subscriptions.go
@@ -243,6 +243,7 @@ func (s Server) ListSubscriptions(ctx echo.Context) error {
 
 	// Obtain the subscription listing.
 	var subscriptions []*model.UserPlan
+	var count int64
 	err = s.GORMDB.Transaction(func(tx *gorm.DB) error {
 		params := &db.UserPlanListingParams{
 			Offset:    int(offset),
@@ -251,7 +252,7 @@ func (s Server) ListSubscriptions(ctx echo.Context) error {
 			SortOrder: sortOrder,
 			Search:    search,
 		}
-		subscriptions, err = db.ListUserPlans(context, tx, params)
+		subscriptions, count, err = db.ListUserPlans(context, tx, params)
 		return err
 	})
 	if err != nil {
@@ -264,6 +265,7 @@ func (s Server) ListSubscriptions(ctx echo.Context) error {
 		ctx,
 		&model.SubscriptionListing{
 			Subscriptions: subscriptions,
+			Total:         count,
 		},
 		http.StatusOK,
 	)

--- a/internal/db/user_plans.go
+++ b/internal/db/user_plans.go
@@ -128,7 +128,7 @@ type UserPlanListingParams struct {
 	Offset    int
 	Limit     int
 	SortField string
-	SortOrder string
+	SortDir   string
 	Search    string
 }
 
@@ -153,8 +153,8 @@ func ListUserPlans(ctx context.Context, db *gorm.DB, params *UserPlanListingPara
 		sortField = params.SortField
 	}
 	order := "asc"
-	if params != nil && params.SortOrder != "" {
-		order = params.SortOrder
+	if params != nil && params.SortDir != "" {
+		order = params.SortDir
 	}
 	orderBy := fmt.Sprintf("%s %s", sortField, order)
 

--- a/internal/db/user_plans.go
+++ b/internal/db/user_plans.go
@@ -122,6 +122,25 @@ func GetUserPlanDetails(ctx context.Context, db *gorm.DB, userPlanID string) (*m
 	return userPlan, err
 }
 
+// ListUserPlans lists subscriptions for multiple users.
+func ListUserPlans(ctx context.Context, db *gorm.DB) ([]*model.UserPlan, error) {
+	var userPlans []*model.UserPlan
+
+	err := db.WithContext(ctx).
+		Preload("User").
+		Preload("Plan").
+		Preload("Plan.PlanQuotaDefaults").
+		Preload("Plan.PlanQuotaDefaults.ResourceType").
+		Preload("Quotas").
+		Preload("Quotas.ResourceType").
+		Preload("Usages").
+		Preload("Usages.ResourceType").
+		Find(&userPlans).
+		Error
+
+	return userPlans, err
+}
+
 // GetActiveUserPlanDetails retrieves the user plan information that is currently active for the user. The effective
 // start date must be before the current date and the effective end date must either be null or after the current date.
 // If multiple active user plans exist, the one with the most recent effective start date is used. If no active user

--- a/internal/model/quota.go
+++ b/internal/model/quota.go
@@ -12,7 +12,7 @@ type Quota struct {
 	ID *string `gorm:"type:uuid;default:uuid_generate_v1()" json:"id,omitempty"`
 
 	// The resource usage limit
-	Quota float64 `json:"quota,omitempty"`
+	Quota float64 `json:"quota"`
 
 	// The user plan ID
 	UserPlanID *string `gorm:"type:uuid;not null" json:"-"`

--- a/internal/model/subscriptions.go
+++ b/internal/model/subscriptions.go
@@ -52,4 +52,7 @@ func SubscriptionResponseFromUserPlan(userPlan *UserPlan, newSubscription bool) 
 type SubscriptionListing struct {
 	// The subscriptions in the listing.
 	Subscriptions []*UserPlan `json:"subscriptions"`
+
+	// The total number of matched subscriptions.
+	Total int64 `json:"total"`
 }

--- a/internal/model/subscriptions.go
+++ b/internal/model/subscriptions.go
@@ -45,3 +45,11 @@ func SubscriptionResponseFromUserPlan(userPlan *UserPlan, newSubscription bool) 
 	resp.NewSubscription = newSubscription
 	return &resp
 }
+
+// SubscriptionListing represents a list of subscriptions.
+//
+// swagger: model
+type SubscriptionListing struct {
+	// The subscriptions in the listing.
+	Subscriptions []*UserPlan `json:"subscriptions"`
+}

--- a/internal/model/usage.go
+++ b/internal/model/usage.go
@@ -12,7 +12,7 @@ type Usage struct {
 	ID *string `gorm:"type:uuid;default:uuid_generate_v1()" json:"id,omitempty"`
 
 	// The usage amount
-	Usage float64 `gorm:"not null" json:"usage,omitempty"`
+	Usage float64 `gorm:"not null" json:"usage"`
 
 	// The subscription identifier
 	UserPlanID *string `gorm:"type:uuid;not null;index:usage_userplan_resourcetype,unique" json:"-"`

--- a/internal/query/main.go
+++ b/internal/query/main.go
@@ -3,6 +3,7 @@ package query
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/go-playground/validator/v10"
 	"github.com/labstack/echo/v4"
@@ -80,4 +81,43 @@ func ValidateIntQueryParam(ctx echo.Context, name string, defaultValue *int32, c
 	}
 
 	return result, nil
+}
+
+// contains returns true if the given slice of strings contains the given string.
+func contains(strs []string, str string) bool {
+	for _, s := range strs {
+		if s == str {
+			return true
+		}
+	}
+	return false
+}
+
+// ValidateEnumQueryParam extracts the value of an enumeration query parameter. The value will always be converted to
+// lower case before validating an returning it.
+func ValidateEnumQueryParam(ctx echo.Context, name string, vals []string, defaultValue *string) (string, error) {
+	value := strings.ToLower(ctx.QueryParam(name))
+
+	// Assume that the value is required if there's no default.
+	if defaultValue == nil && value == "" {
+		return "", fmt.Errorf("missing required query parameter: %s", name)
+	}
+
+	// If no value was provide at this point then the parameter is optionl; return the default value.
+	if value == "" {
+		return *defaultValue, nil
+	}
+
+	// Validate the value.
+	if !contains(vals, value) {
+		return "", fmt.Errorf("invalid query parameter: %s; valid values: %s", name, strings.Join(vals, ", "))
+	}
+	return value, nil
+}
+
+// ValidateSortOrder extracts the value of a sort order query parameter and validates it. The value will always be
+// converted to lower case before validating and returning it.
+func ValidateSortOrder(ctx echo.Context) (string, error) {
+	defaultSortOrder := "asc"
+	return ValidateEnumQueryParam(ctx, "sort-order", []string{"asc", "desc"}, &defaultSortOrder)
 }

--- a/internal/query/main.go
+++ b/internal/query/main.go
@@ -115,9 +115,9 @@ func ValidateEnumQueryParam(ctx echo.Context, name string, vals []string, defaul
 	return value, nil
 }
 
-// ValidateSortOrder extracts the value of a sort order query parameter and validates it. The value will always be
+// ValidateSortDir extracts the value of a sort direction query parameter and validates it. The value will always be
 // converted to lower case before validating and returning it.
-func ValidateSortOrder(ctx echo.Context) (string, error) {
-	defaultSortOrder := "asc"
-	return ValidateEnumQueryParam(ctx, "sort-order", []string{"asc", "desc"}, &defaultSortOrder)
+func ValidateSortDir(ctx echo.Context) (string, error) {
+	defaultSortDir := "asc"
+	return ValidateEnumQueryParam(ctx, "sort-dir", []string{"asc", "desc"}, &defaultSortDir)
 }

--- a/internal/query/main.go
+++ b/internal/query/main.go
@@ -48,3 +48,36 @@ func ValidateBooleanQueryParam(ctx echo.Context, name string, defaultValue *bool
 	}
 	return result, nil
 }
+
+// ValidateIntQueryParam extracts an optional integer query parameter and validates it.
+func ValidateIntQueryParam(ctx echo.Context, name string, defaultValue *int32, checks ...string) (int32, error) {
+	errMsg := fmt.Sprintf("invalid query parameter: %s", name)
+	value := ctx.QueryParam(name)
+	var result int32
+
+	// Assume that the parameter is required if there's no default.
+	if defaultValue == nil && value == "" {
+		return result, fmt.Errorf("missing rquired query parameter: %s", name)
+	}
+
+	// If no value was provided at this point then the parameter is optional; return the default value.
+	if value == "" {
+		return *defaultValue, nil
+	}
+
+	// Parse the parameter value.
+	parsed, err := strconv.ParseInt(value, 10, 32)
+	if err != nil {
+		return result, errors.Wrap(err, errMsg)
+	}
+	result = int32(parsed)
+
+	// Perform any checks that we're supposed to perform.
+	for _, check := range checks {
+		if err = v.Var(result, check); err != nil {
+			return result, errors.Wrap(err, errMsg)
+		}
+	}
+
+	return result, nil
+}

--- a/internal/swagger/swagger.go
+++ b/internal/swagger/swagger.go
@@ -178,11 +178,11 @@ type ListSubscriptionsParameters struct {
 	// in: query
 	SortField string `json:"sort-field"`
 
-	// The sort order to use for the listing
+	// The sort direction to use for the listing
 	//
 	// enum: asc,desc
 	// in: query
-	SortOrder string `json:"sort-order"`
+	SortDir string `json:"sort-dir"`
 
 	// The username substring to search for in the listing
 	//

--- a/internal/swagger/swagger.go
+++ b/internal/swagger/swagger.go
@@ -157,6 +157,20 @@ type SubscriptionsResponse struct {
 	}
 }
 
+// Subscription Listing
+//
+// swagger:response subscriptionListing
+type SubscriptionListing struct {
+
+	// in:body
+	Body struct {
+		ResponseBodyWrapper
+
+		// The list of subscriptions
+		Result []model.SubscriptionListing
+	}
+}
+
 // Plan Listing
 //
 // swagger:response plansResponse

--- a/internal/swagger/swagger.go
+++ b/internal/swagger/swagger.go
@@ -157,6 +157,22 @@ type SubscriptionsResponse struct {
 	}
 }
 
+// Subscription listing parameters.
+//
+// swagger:parameters listSubscriptions
+type ListSubscriptionsParameters struct {
+
+	// The starting offset for the listing
+	//
+	// in: query
+	Offset int32 `json:"offset"`
+
+	// The maximum number of subscriptions to include in the listing.
+	//
+	// in: query
+	Limit int32 `json:"limit"`
+}
+
 // Subscription Listing
 //
 // swagger:response subscriptionListing

--- a/internal/swagger/swagger.go
+++ b/internal/swagger/swagger.go
@@ -171,6 +171,18 @@ type ListSubscriptionsParameters struct {
 	//
 	// in: query
 	Limit int32 `json:"limit"`
+
+	// The sort field to use for the listing
+	//
+	// enum: username,start-date,end-date
+	// in: query
+	SortField string `json:"sort-field"`
+
+	// The sort order to use for the listing
+	//
+	// enum: asc,desc
+	// in: query
+	SortOrder string `json:"sort-order"`
 }
 
 // Subscription Listing

--- a/internal/swagger/swagger.go
+++ b/internal/swagger/swagger.go
@@ -167,7 +167,7 @@ type ListSubscriptionsParameters struct {
 	// in: query
 	Offset int32 `json:"offset"`
 
-	// The maximum number of subscriptions to include in the listing.
+	// The maximum number of subscriptions to include in the listing
 	//
 	// in: query
 	Limit int32 `json:"limit"`
@@ -183,6 +183,11 @@ type ListSubscriptionsParameters struct {
 	// enum: asc,desc
 	// in: query
 	SortOrder string `json:"sort-order"`
+
+	// The username substring to search for in the listing
+	//
+	// in: query
+	Search string `json:"search"`
 }
 
 // Subscription Listing

--- a/server/router.go
+++ b/server/router.go
@@ -98,6 +98,8 @@ func RegisterHandlers(s controllers.Server) {
 	subscriptions := v1.Group("/subscriptions")
 	subscriptions.POST("", s.AddSubscriptions)
 	subscriptions.POST("/", s.AddSubscriptions)
+	subscriptions.GET("", s.ListSubscriptions)
+	subscriptions.GET("/", s.ListSubscriptions)
 
 	usages := v1.Group("/usages")
 	usages.GET("/:username", s.GetAllUsageOfUser)


### PR DESCRIPTION
Here's the Swagger documentation:

![image](https://user-images.githubusercontent.com/415143/203180322-d5e145ca-b864-431d-83c6-0df4a0351b05.png)

Here's an example endpoint call:

```
$ curl -s "http://localhost:9000/v1/subscriptions?search=sarahr&limit=1" | jq
{
  "result": {
    "subscriptions": [
      {
        "id": "c9ff4c16-4680-11ed-9aa7-62d47aced14b",
        "effective_start_date": "2022-10-07T13:44:07.703734-07:00",
        "effective_end_date": "2023-10-07T13:44:07.703734-07:00",
        "user": {
          "id": "cd7b20f2-03bb-11ed-b868-62d47aced14b",
          "username": "sarahr"
        },
        "plan": {
          "id": "cdf7ac7a-98dc-11ec-bbe3-406c8f3e9cbb",
          "name": "Pro",
          "description": "Professional plan",
          "plan_quota_defaults": [
            {
              "id": "7efddabe-47d6-401c-b857-d08361397fcf",
              "quota_value": 2000,
              "resource_type": {
                "id": "99e3bc7e-950a-11ec-84a4-406c8f3e9cbb",
                "name": "cpu.hours",
                "unit": "cpu hours"
              }
            },
            {
              "id": "2c39ff2f-2ec7-4ac8-a10e-79fd82b39c09",
              "quota_value": 3298534883328,
              "resource_type": {
                "id": "99e3f91e-950a-11ec-84a4-406c8f3e9cbb",
                "name": "data.size",
                "unit": "bytes"
              }
            }
          ]
        },
        "quotas": [
          {
            "id": "ca13a58a-4680-11ed-9aa7-62d47aced14b",
            "quota": 2000,
            "resource_type": {
              "id": "99e3bc7e-950a-11ec-84a4-406c8f3e9cbb",
              "name": "cpu.hours",
              "unit": "cpu hours"
            },
            "last_modified_at": "2022-10-07T13:10:12.465227-07:00"
          },
          {
            "id": "ca13ad46-4680-11ed-9aa7-62d47aced14b",
            "quota": 3298534883328,
            "resource_type": {
              "id": "99e3f91e-950a-11ec-84a4-406c8f3e9cbb",
              "name": "data.size",
              "unit": "bytes"
            },
            "last_modified_at": "2022-10-07T13:10:12.465227-07:00"
          }
        ],
        "usages": [
          {
            "id": "244a0a6a-4f43-11ed-8757-62d47aced14b",
            "usage": 0.0500212755555556,
            "resource_type": {
              "id": "99e3bc7e-950a-11ec-84a4-406c8f3e9cbb",
              "name": "cpu.hours",
              "unit": "cpu hours"
            },
            "last_modified_at": "2022-10-18T17:15:30.776001-07:00"
          },
          {
            "id": "ca1bd868-4680-11ed-9aa7-62d47aced14b",
            "usage": 25954416,
            "resource_type": {
              "id": "99e3f91e-950a-11ec-84a4-406c8f3e9cbb",
              "name": "data.size",
              "unit": "bytes"
            },
            "last_modified_at": "2022-11-07T11:45:34.660448-07:00"
          }
        ]
      }
    ],
    "total": 3
  },
  "status": "OK"
}
```
