### PR TITLE
CORE-1832: replace the endpoint to update user quotas.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18
+FROM golang:1.19
 
 RUN go install github.com/jstemmer/go-junit-report@latest
 

--- a/internal/httpmodel/quota_value.go
+++ b/internal/httpmodel/quota_value.go
@@ -1,0 +1,9 @@
+package httpmodel
+
+// QuotaValue represents a single quota value for which the resource type name is provided elsewhere.
+//
+// swagger: model
+type QuotaValue struct {
+	// The resource usage limit.
+	Quota float64 `json:"quota" validate:"required"`
+}

--- a/internal/model/plan.go
+++ b/internal/model/plan.go
@@ -89,10 +89,10 @@ type UserPlan struct {
 	Plan *Plan `json:"plan,omitempty"`
 
 	// The quotas associated with the subscription
-	Quotas []Quota `json:"quotas,omitempty"`
+	Quotas []Quota `json:"quotas"`
 
 	// The recorded usage amounts associated with the subscription
-	Usages []Usage `json:"usages,omitempty"`
+	Usages []Usage `json:"usages"`
 }
 
 // GetCurrentUsageValue returns the current usage value for the resource type with the given resource type ID. Be

--- a/internal/swagger/swagger.go
+++ b/internal/swagger/swagger.go
@@ -277,13 +277,6 @@ type AddPlanQuotaDefaults struct {
 	Body controllers.PlanQuotaDefaultValues
 }
 
-type QuotaResponseWrapper struct {
-	// The quota information
-	//
-	//in: body
-	Body controllers.QuotaReq
-}
-
 // Users
 
 // User Listing

--- a/internal/swagger/swagger.go
+++ b/internal/swagger/swagger.go
@@ -125,6 +125,25 @@ type SuccessMessageResponseWrapoper struct {
 	}
 }
 
+// Parameters for the endpoint used to update a user's current quota value for a specific resource type.
+//
+// swagger:parameters updateCurrentSubscriptionQuota
+type UpdateCurrentSubscriptionQuotaParameters struct {
+
+	// The username of the user whose subscription should be updated.
+	//
+	// in: query
+	Username string `json:"username"`
+
+	// The name of the resource type to update the quota for.
+	//
+	// in: query
+	ResourceTypeName string `json:"resource-type"`
+
+	// in: body
+	Body httpmodel.QuotaValue
+}
+
 // Parameters for the endpoint used to add multiple subscriptions.
 //
 // swagger:parameters addSubscriptions

--- a/server/router.go
+++ b/server/router.go
@@ -50,9 +50,6 @@ func registerUserEndpoints(users *echo.Group, s *controllers.Server) {
 	// Lists all of the active user plans.
 	users.GET("/all_active_users", s.GetAllActiveUserPlans)
 
-	// Updates or adds a quota (read as limit) to a user's current plan.
-	users.POST("/quota", s.AddQuota)
-
 	// Adds a new user to the database.
 	users.PUT("/:username", s.AddUser)
 

--- a/server/router.go
+++ b/server/router.go
@@ -3,12 +3,23 @@ package server
 import (
 	"github.com/cyverse-de/echo-middleware/v2/redoc"
 	"github.com/cyverse/QMS/internal/controllers"
+	"github.com/go-playground/validator/v10"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 	"github.com/sirupsen/logrus"
 	echolog "github.com/spirosoik/echo-logrus"
 	"go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho"
 )
+
+// CustomValidator represents a validator that Echo can use to check incoming requests.
+type CustomValidator struct {
+	validator *validator.Validate
+}
+
+// Validate performs validation for an incoming request.
+func (cv CustomValidator) Validate(i interface{}) error {
+	return cv.validator.Struct(i)
+}
 
 func InitRouter() *echo.Echo {
 	log := log.WithFields(logrus.Fields{"context": "router"})
@@ -26,6 +37,9 @@ func InitRouter() *echo.Echo {
 	e.Use(middleware.Recover())
 	e.Use(redoc.Serve(redoc.Opts{Title: "CyVerse Quota Management System"}))
 
+	// Register a custom validator.
+	e.Validator = &CustomValidator{validator: validator.New()}
+
 	return e
 }
 
@@ -42,8 +56,11 @@ func registerUserEndpoints(users *echo.Group, s *controllers.Server) {
 	// Adds a new user to the database.
 	users.PUT("/:username", s.AddUser)
 
-	// Gets a users's current plan details
+	// Gets a user's current plan details
 	users.GET("/:username/plan", s.GetUserPlanDetails)
+
+	// Updates a quota in the user's current subscription plan.
+	users.POST("/:username/plan/:resource-type/quota", s.UpdateCurrentSubscriptionQuota)
 
 	// GET /:username/resources/overages returns summaries of any usages that exceed the quota for the corresponding resource.
 	users.GET("/:username/resources/overages", s.GetUserOverages)


### PR DESCRIPTION
This PR makes the following changes:

- Removes an existing endpoint: `/v1/users/quota`
- Adds a new endpoint: `/v1/users/:username/plan/:resource-type/quota`

The new endpoint supersedes the old endpoint and is more convenient for utilities that simply want to update a user's current quota.

There's also a change that was deployed to production last month, but hadn't been merged into the main fork yet.
