### PR TITLE
CORE-1838: Add subscription_addons table

### DIFF
--- a/migrations/000010_subscription_addons.down.sql
+++ b/migrations/000010_subscription_addons.down.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+SET search_path = public, pg_catalog;
+
+DROP TABLE IF EXISTS subscription_addons;
+
+COMMIT;

--- a/migrations/000010_subscription_addons.up.sql
+++ b/migrations/000010_subscription_addons.up.sql
@@ -1,0 +1,21 @@
+--
+-- Adds a table that tracks which addons have been applied to a subscription.
+--
+
+BEGIN;
+
+SET search_path = public, pg_catalog;
+
+CREATE TABLE IF NOT EXISTS subscription_addons (
+    id uuid NOT NULL DEFAULT uuid_generate_v4(),
+    subscription_id uuid NOT NULL,
+    addon_id uuid NOT NULL,
+    amount numeric NOT NULL,
+    paid boolean NOT NULL DEFAULT true,
+
+    FOREIGN KEY (subscription_id) REFERENCES subscriptions(id) ON DELETE CASCADE,
+    FOREIGN KEY (addon_id) REFERENCES addons(id) ON DELETE CASCADE,
+    PRIMARY KEY (id)
+);
+
+COMMIT;


### PR DESCRIPTION
See: https://cyverse.atlassian.net/browse/CORE-1838

Must be merged after:
* https://github.com/cyverse/QMS/pull/53 
* https://github.com/cyverse/QMS/pull/54

Adds the subscription_addons table to the QMS database, which tracks which addons have been applied to a subscription and the parameters of the addon, including whether it's a paid addon and how many resource units it grants.