### PR TITLE
added a conversion for the data add-on

### DIFF
--- a/migrations/000012_data_addon.down.sql
+++ b/migrations/000012_data_addon.down.sql
@@ -1,0 +1,11 @@
+--
+-- Deletes the add-on for data-only subscriptions.
+--
+
+BEGIN;
+
+SET search_path = public, pg_catalog;
+
+DELETE FROM addons WHERE id = 'c21dd61f-aa41-40ad-8005-859679ceed9c';
+
+COMMIT;

--- a/migrations/000012_data_addon.up.sql
+++ b/migrations/000012_data_addon.up.sql
@@ -1,0 +1,20 @@
+--
+-- Creates an add-on for data-only subscriptions.
+--
+
+BEGIN;
+
+SET search_path = public, pg_catalog;
+
+INSERT INTO addons (id, name, description, resource_type_id, default_amount, default_paid)
+VALUES (
+    'c21dd61f-aa41-40ad-8005-859679ceed9c',
+    '1 TB',
+    '1 TB of data storage for one year.',
+    (SELECT id FROM resource_types WHERE name = 'data.size'),
+    power(2, 40),
+    TRUE
+)
+ON CONFLICT DO NOTHING;
+
+COMMIT;


### PR DESCRIPTION
I could have used the API to create this, but database migrations were used for the initial set of subscription plans as well. I thought I'd create migrations for this for the sake of consistency.