### PR TITLE
CORE-2017: added an endpoint to list all subscriptions for a user

### DIFF
--- a/internal/swagger/swagger.go
+++ b/internal/swagger/swagger.go
@@ -208,6 +208,24 @@ type ListSubscriptionsParameters struct {
 	Search string `json:"search"`
 }
 
+// Subscription Listing Parameters for a single user.
+//
+// swagger:parameters listUserSubscriptions
+type ListUserSubscriptionsParameters struct {
+
+	// Whether to include expired subscriptions in the listing
+	//
+	// in: query
+	// default: false
+	IncludeExpired bool `json:"include-expired"`
+
+	// The cutoff date for expired subscriptions
+	//
+	// in: query
+	// default: current timestamp
+	Cutoff string `json:"cutoff"`
+}
+
 // Subscription Listing
 //
 // swagger:response subscriptionListing

--- a/server/router.go
+++ b/server/router.go
@@ -56,6 +56,8 @@ func registerUserEndpoints(users *echo.Group, s *controllers.Server) {
 
 	// Changes the user's current plan to one corresponding to plan name.
 	users.PUT("/:username/:plan_name", s.UpdateSubscription)
+
+	users.GET("/:username/subscriptions", s.ListUserSubscriptions)
 }
 
 func registerPlanEndpoints(plans *echo.Group, s *controllers.Server) {


### PR DESCRIPTION
Now that users can have subscriptions that start in the future, Phoenix Bioinformatics needs to be able to list future subscriptions in order to determine if a user is eligible to renew their subscription.