### PR TITLE
initial setup for a metadata field on the updates table, 

### DIFF
--- a/internal/controllers/usages.go
+++ b/internal/controllers/usages.go
@@ -20,6 +20,7 @@ type Usage struct {
 	ResourceName string  `json:"resource_name"`
 	UsageValue   float64 `json:"usage_value"`
 	UpdateType   string  `json:"update_type"`
+	Metadata     string  `json:"metadata"`
 }
 
 var (
@@ -138,6 +139,7 @@ func (s Server) addUsage(ctx context.Context, usage *Usage) error {
 			UpdateOperationID: updateOperation.ID,
 			ResourceTypeID:    resourceType.ID,
 			UserID:            subscription.UserID,
+			Metadata:          &usage.Metadata,
 		}
 		err = tx.WithContext(ctx).Debug().Create(&update).Error
 		if err != nil {

--- a/internal/model/update.go
+++ b/internal/model/update.go
@@ -34,4 +34,5 @@ type Update struct {
 	ResourceType      ResourceType `json:"resource_types"`
 	UserID            *string      `gorm:"type:uuid" json:"-"`
 	User              User         `json:"user"`
+	Metadata          *string      `json:"metadata"`
 }

--- a/migrations/000017_updates_metadata.down.sql
+++ b/migrations/000017_updates_metadata.down.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+SET search_path = public, pg_catalog;
+
+ALTER TABLE IF EXISTS updates DROP COLUMN IF EXISTS metadata;
+
+COMMIT;

--- a/migrations/000017_updates_metadata.up.sql
+++ b/migrations/000017_updates_metadata.up.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+SET search_path = public, pg_catalog;
+
+ALTER TABLE IF EXISTS updates ADD COLUMN IF NOT EXISTS metadata TEXT;
+
+COMMIT;


### PR DESCRIPTION
intended to be used for storing arbitrary info useful for debugging and auditing -- in particular, for keeping track of what analyses correspond to what updates, and what dates are being used for the calculations, for the sake of double-counting avoidance